### PR TITLE
Fix overlap faces

### DIFF
--- a/dlib/image_processing/frontal_face_detector.h
+++ b/dlib/image_processing/frontal_face_detector.h
@@ -20,6 +20,8 @@ namespace dlib
         std::istringstream sin(get_serialized_frontal_faces());
         frontal_face_detector detector;
         deserialize(detector, sin);
+		test_box_overlap overlap(0.15, 0.75);
+		detector.set_overlap_tester(overlap);
         return detector;
     }
 

--- a/dlib/image_processing/object_detector.h
+++ b/dlib/image_processing/object_detector.h
@@ -112,6 +112,9 @@ namespace dlib
         const test_box_overlap& get_overlap_tester (
         ) const;
 
+		void set_overlap_tester(test_box_overlap boxes_overlap_
+		);
+
         const image_scanner_type& get_scanner (
         ) const;
 
@@ -604,6 +607,17 @@ namespace dlib
     {
         return boxes_overlap;
     }
+
+	template <
+		typename image_scanner_type
+	>
+		void object_detector<image_scanner_type>::
+		set_overlap_tester(test_box_overlap boxes_overlap_
+		)
+	{
+		boxes_overlap = boxes_overlap_;
+	}
+
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION


### Add setting threshold function and set the correct values to avoid the wrong detection of the face.

![img](https://github.com/glaba13/ImageResources/blob/master/ba.png?raw=true)
Once it's merged need to be called on facemask plugin local repository:
`git submodule update --remote --merge`