### PR TITLE
Pushing this code to plugin side

### DIFF
--- a/dlib/image_processing/frontal_face_detector.h
+++ b/dlib/image_processing/frontal_face_detector.h
@@ -20,8 +20,6 @@ namespace dlib
         std::istringstream sin(get_serialized_frontal_faces());
         frontal_face_detector detector;
         deserialize(detector, sin);
-		test_box_overlap overlap(0.15, 0.75);
-		detector.set_overlap_tester(overlap);
         return detector;
     }
 


### PR DESCRIPTION
This PR pushes the box overlap setting to outside the DLIB library.